### PR TITLE
✨ Feat: 대시보드 삭제 구현 

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -71,6 +71,12 @@ export const editBoard = async (body: BoardState, boardId: number) => {
   return res.data
 }
 
+// 대시보드 삭제
+export const deleteDashboard = async (boardId: number) => {
+  const res = await authInstance.delete(`/dashboard/${boardId}`)
+  return res.data
+}
+
 //디데이 목록 조회
 export const getDdayList = async (widgetId: number | null) => {
   const res = await authInstance.get(`/dday/${widgetId}`)

--- a/src/components/editboard/BoardDeleteButton.tsx
+++ b/src/components/editboard/BoardDeleteButton.tsx
@@ -1,0 +1,54 @@
+import { LuTrash2 } from 'react-icons/lu'
+import { useRecoilState, useSetRecoilState } from 'recoil'
+
+import { deleteDashboard } from '@/api'
+import {
+  DASHBOARD_DELETE_COMFIRM_ALERT,
+  DASHBOARD_DELETE_FAIL_ALERT,
+  DASHBOARD_DELETE_SUCCESS_ALERT,
+} from '@/constants/alert'
+import { useAlert } from '@/hooks/useAlert'
+import { boardListAtom, currentBoardIdAtom } from '@/store/boardState'
+
+interface BoardDeleteButtonProps {
+  listId: number
+}
+
+const BoardDeleteButton = ({ listId }: BoardDeleteButtonProps) => {
+  const { openAlert } = useAlert()
+  const [boardListData, setBoardList] = useRecoilState(boardListAtom)
+  const setCurrentBoardId = useSetRecoilState(currentBoardIdAtom)
+
+  const deleteBoard = async (boardId: number) => {
+    try {
+      const res = await deleteDashboard(boardId)
+      if (res) {
+        openAlert(DASHBOARD_DELETE_SUCCESS_ALERT)
+        setBoardList((prevList) => prevList.filter((board) => board.id !== boardId))
+
+        setCurrentBoardId((prevBoardId) => {
+          const newBoardList = boardListData.filter((board) => board.id !== boardId)
+          if (prevBoardId === boardId && newBoardList.length > 0) {
+            return newBoardList[0].id
+          }
+          return prevBoardId
+        })
+      }
+    } catch (error) {
+      openAlert(DASHBOARD_DELETE_FAIL_ALERT)
+    }
+  }
+
+  const handleClickDelete = (e: React.MouseEvent<HTMLDivElement, MouseEvent>, boardId: number) => {
+    e.stopPropagation()
+    openAlert({ ...DASHBOARD_DELETE_COMFIRM_ALERT, buttonTitle: '삭제', callback: () => deleteBoard(boardId) })
+  }
+
+  return (
+    <div onClick={(e) => handleClickDelete(e, listId)}>
+      <LuTrash2 />
+    </div>
+  )
+}
+
+export default BoardDeleteButton

--- a/src/components/editboard/BoardList.tsx
+++ b/src/components/editboard/BoardList.tsx
@@ -2,12 +2,13 @@ import { css, useTheme } from '@emotion/react'
 import { Theme } from '@emotion/react'
 import { useEffect } from 'react'
 import { FaArrowDownLong, FaArrowUp } from 'react-icons/fa6'
-import { LuTrash2 } from 'react-icons/lu'
 import { useRecoilState, useRecoilValue } from 'recoil'
 import BoardAddButton from './BoardAddButton'
+import BoardDeleteButton from './BoardDeleteButton'
 
 import { useBoardListFetch } from '@/hooks/useBoardListFetch'
 import { boardListAtom, currentBoardIdAtom } from '@/store/boardState'
+
 const BoardList = () => {
   const [currentBoardId, setCurrentBoardId] = useRecoilState(currentBoardIdAtom)
   const { fetchBoardList } = useBoardListFetch()
@@ -26,11 +27,6 @@ const BoardList = () => {
     setCurrentBoardId(boardId)
   }
 
-  const handleClickDelete = (e: React.MouseEvent<HTMLDivElement, MouseEvent>, boardId: number) => {
-    e.stopPropagation()
-    alert(`delete ${boardId}`)
-  }
-
   return (
     <div css={container}>
       <div css={leftWrap}>
@@ -46,9 +42,7 @@ const BoardList = () => {
               css={listItem(theme, isCurrentBoard(currentBoardId, item.id))}
             >
               <div>{item.title}</div>
-              <div onClick={(e) => handleClickDelete(e, item.id)}>
-                <LuTrash2 />
-              </div>
+              <BoardDeleteButton listId={item.id} />
             </div>
           ))}
         </div>

--- a/src/constants/alert.ts
+++ b/src/constants/alert.ts
@@ -145,3 +145,27 @@ export const DASHBOARD_ADD_FAILED_ALERT = {
   buttonType: AlertButtonType.Close,
   notiType: AlertNotificationType.Error,
 }
+
+export const DASHBOARD_DELETE_COMFIRM_ALERT = {
+  icon: '🔔',
+  title: '대시보드를 삭제하시겠습니까?',
+  content: '저장된 대시보드 정보가 전부 삭제되며 복구할 수 없습니다. \n정말 삭제하시겠습니까?',
+  buttonType: AlertButtonType.CloseAndOk,
+  notiType: AlertNotificationType.Warning,
+}
+
+export const DASHBOARD_DELETE_FAIL_ALERT = {
+  icon: '🚨',
+  title: '대시보드 삭제 실패',
+  content: '대시보드 삭제에 실패했습니다. \n잠시 후 다시 시도해주세요.',
+  buttonType: AlertButtonType.Close,
+  notiType: AlertNotificationType.Error,
+}
+
+export const DASHBOARD_DELETE_SUCCESS_ALERT = {
+  icon: '👌',
+  title: '대시보드 삭제 완료',
+  content: '',
+  buttonType: AlertButtonType.None,
+  notiType: AlertNotificationType.Success,
+}

--- a/src/mocks/dashboard.handler.ts
+++ b/src/mocks/dashboard.handler.ts
@@ -5,6 +5,8 @@ import { defaultBoardData } from './data'
 import {
   RES_DASHBOARD_CREATE_FAIL,
   RES_DASHBOARD_CREATE_SUCCESS,
+  RES_DASHBOARD_DELETE_SUCCESS,
+  RES_DASHBOARD_FAIL_NOT_FOUND,
   RES_DASHBOARD_ID_FAIL_INVALID,
   RES_DASHBOARD_LIST_RETRIEVED_SUCCESS,
   RES_DASHBOARD_LIST_RETRIEVED_SUCCESS_EMPTY,
@@ -119,6 +121,20 @@ export const dashboardHandlers = [
     MSW_DASHBOARD_LAYOUTS[newKey] = defaultBoardData
 
     return HttpResponse.json(RES_DASHBOARD_CREATE_SUCCESS.res, { status: RES_DASHBOARD_CREATE_SUCCESS.code })
+  }),
+
+  //대시보드 삭제
+  http.delete('/dashboard/:boardId', async ({ params }) => {
+    const { boardId } = params
+    const index = boardListData.findIndex((board) => board.id === Number(boardId))
+
+    if (index === -1) {
+      return HttpResponse.json(RES_DASHBOARD_FAIL_NOT_FOUND.res, { status: RES_DASHBOARD_FAIL_NOT_FOUND.code })
+    }
+
+    boardListData.splice(index, 1)
+
+    return HttpResponse.json(RES_DASHBOARD_DELETE_SUCCESS.res, { status: RES_DASHBOARD_DELETE_SUCCESS.code })
   }),
 
   //대시보드 수정

--- a/src/mocks/resMessage.ts
+++ b/src/mocks/resMessage.ts
@@ -88,6 +88,33 @@ export const RES_DASHBOARD_CREATE_SUCCESS = {
   code: 201,
 }
 
+//대시보드 삭제 실패
+export const RES_DASHBOARD_DELETE_FAIL = {
+  res: {
+    success: false,
+    message: 'Failed to delete dashboard',
+  },
+  code: 400,
+}
+
+//대시보드 삭제 성공
+export const RES_DASHBOARD_DELETE_SUCCESS = {
+  res: {
+    success: true,
+    message: 'Dashboard deleted successfully',
+  },
+  code: 201,
+}
+
+//대시보드 수정,삭제 실패: 해당 아이디 없음
+export const RES_DASHBOARD_FAIL_NOT_FOUND = {
+  res: {
+    success: false,
+    message: 'Dashboard not found',
+  },
+  code: 404,
+}
+
 //대시보드 목록 조회 성공
 export const RES_DASHBOARD_LIST_RETRIEVED_SUCCESS = {
   res: {


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

대시보드 편집화면의 대시보드 목록에서 버튼 클릭을 통한 삭제 구현 
선택된 보드를 삭제할 경우 현재 보드 id를 변경 
그렇지 않다면 그대로 유지하도록 구현 

대시보드 삭제 관련해 api, msw 핸들러와 메세지 alert 를 추가 

현재 mock 데이터 고정 계정(test@planary.com)기준 2가지 대시보드가 기본 으로 설정되어있어 
추가 삭제 테스트 시 현재 길이 +1 로 아이디가 생성되기 때문에 생성되는 보드 id가 겹쳐 혼동이 올 수 있습니다. 
기존 2번 보드가 있는상태에서 추가삭제를 반복해 보드 2번 이 2가지가 될 수 있어 이경우 선택된 보드가 2가지로 나옵니다. (오류주의) 

데이터베이스 연동 시 정상적인 동작을 하는지 확인이 필요합니다. 

<br />

## 변경사항

기존 대시보드 목록에서 삭제버튼을 컴포넌트로 분리해 구현했습니다. 

<br />

## 코드 참고사항

close #53 