### PR TITLE
🐛 Fix: 대시보드 편집 수정 

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -67,7 +67,7 @@ export const getBoard = async (boardId: number | null) => {
 
 //대시보드 수정
 export const editBoard = async (body: BoardState, boardId: number) => {
-  const res = await authInstance.post(`/api/board/${boardId}`, body)
+  const res = await authInstance.put(`/dashboard/${boardId}`, body)
   return res.data
 }
 

--- a/src/components/editboard/BoardList.tsx
+++ b/src/components/editboard/BoardList.tsx
@@ -6,14 +6,18 @@ import { useRecoilState, useRecoilValue } from 'recoil'
 import BoardAddButton from './BoardAddButton'
 import BoardDeleteButton from './BoardDeleteButton'
 
+import { DASHBOARD_UPDATE_CONFIRM_ALERT } from '@/constants/alert'
+import { useAlert } from '@/hooks/useAlert'
 import { useBoardListFetch } from '@/hooks/useBoardListFetch'
-import { boardListAtom, currentBoardIdAtom } from '@/store/boardState'
+import { boardDirtyFlag, boardListAtom, currentBoardIdAtom } from '@/store/boardState'
 
 const BoardList = () => {
   const [currentBoardId, setCurrentBoardId] = useRecoilState(currentBoardIdAtom)
   const { fetchBoardList } = useBoardListFetch()
   const boardListData = useRecoilValue(boardListAtom)
   const theme = useTheme()
+  const [isDirty, setIsDirty] = useRecoilState<boolean>(boardDirtyFlag)
+  const { openAlert } = useAlert()
 
   useEffect(() => {
     fetchBoardList()
@@ -24,7 +28,16 @@ const BoardList = () => {
   }
 
   const handleClickItem = (boardId: number) => {
-    setCurrentBoardId(boardId)
+    if (boardId === currentBoardId) return
+
+    const changeBoard = () => {
+      setCurrentBoardId(boardId)
+      setIsDirty(false)
+    }
+
+    isDirty
+      ? openAlert({ ...DASHBOARD_UPDATE_CONFIRM_ALERT, buttonTitle: '확인', callback: changeBoard })
+      : changeBoard()
   }
 
   return (

--- a/src/components/editboard/BoardPreview.tsx
+++ b/src/components/editboard/BoardPreview.tsx
@@ -38,13 +38,6 @@ const BoardPreview = () => {
   }, [boardData, setEditableBoard])
 
   const handleClickDelete = (itemId: string) => {
-    /* setEditableBoard((prevBoards) => {
-      const updatedBoards = {
-        ...prevBoards,
-        lg: prevBoards.lg.filter((item: BoardItem) => item.i !== itemId),
-      }
-      return updatedBoards
-    }) */
     setEditableBoard((prevBoards) => {
       const updatedBoards = {
         ...prevBoards,
@@ -145,8 +138,10 @@ const BoardPreview = () => {
       const updatedWidth = isInvalidSize ? foundItem.w : newItem.w
       const updatedHeight = isInvalidSize ? foundItem.h : newItem.h
 
-      setResizeUpdates((prevBoards: BoardState) => {
-        const updatedLayouts = prevBoards.lg.map((item) => {
+      //?HACK: 배치 이후 리사이징할때 리사이징 이전 배치로 돌아가지 않게하기위해 직접 변경, 현재는 문제가 없으나
+      //?HACK: prev 를 사용하는게 일반적, 이후 문제 발생 가능성 높아 임시로 정상동작 위해 구현, 수정필요
+      setResizeUpdates(() => {
+        const updatedLayouts = editableBoard.lg.map((item) => {
           if (item.i === newItem.i) {
             return {
               ...item,
@@ -162,7 +157,7 @@ const BoardPreview = () => {
           }
           return item
         })
-        return { ...prevBoards, lg: updatedLayouts }
+        return { lg: updatedLayouts }
       })
 
       if (isInvalidSize) {

--- a/src/components/editboard/BoardSaveButton.tsx
+++ b/src/components/editboard/BoardSaveButton.tsx
@@ -16,9 +16,11 @@ const BoardSaveButton = () => {
 
   const onSave = async () => {
     try {
-      const res = await editBoard(boards, boardId)
-      if (res.success) {
-        openAlert(BOARD_EDIT_SAVE_SUCCESS)
+      if (boardId) {
+        const res = await editBoard(boards, boardId)
+        if (res.success) {
+          openAlert(BOARD_EDIT_SAVE_SUCCESS)
+        }
       }
     } catch (error) {
       openAlert(BOARD_EDIT_SAVE_FAILED)

--- a/src/constants/alert.ts
+++ b/src/constants/alert.ts
@@ -169,3 +169,11 @@ export const DASHBOARD_DELETE_SUCCESS_ALERT = {
   buttonType: AlertButtonType.None,
   notiType: AlertNotificationType.Success,
 }
+
+export const DASHBOARD_UPDATE_CONFIRM_ALERT = {
+  icon: '🔔',
+  title: '대시보드 편집 내역 미저장',
+  content: '편집 내역이 저장되지 않은 대시보드가 있습니다. \n저장하지 않고 이동하시겠습니까?',
+  buttonType: AlertButtonType.CloseAndOk,
+  notiType: AlertNotificationType.Warning,
+}

--- a/src/mocks/dashboard.handler.ts
+++ b/src/mocks/dashboard.handler.ts
@@ -12,6 +12,7 @@ import {
   RES_DASHBOARD_LIST_RETRIEVED_SUCCESS_EMPTY,
   RES_DASHBOARD_RETRIEVED_SUCCESS,
   RES_DASHBOARD_RETRIEVED_SUCCESS_EMPTY,
+  RES_DASHBOARD_UPDATE_SUCCESS,
   RES_INTERNAL_SERVER_ERROR,
 } from './resMessage'
 import { authenticateRequest } from './utils'
@@ -138,25 +139,19 @@ export const dashboardHandlers = [
   }),
 
   //대시보드 수정
-  /* http.post('/api/board/:boardId', async ({ request, params }) => {
-    const token = request.headers.get('Authorization')
+  http.put('/dashboard/:boardId', async ({ request, params }) => {
     const { boardId } = params
 
-    const result = await request.json()
+    const updateData = (await request.json()) as Partial<DashboardBody>
 
-    const data = {
-      success: true,
+    const index = boardListData.findIndex((board) => board.id === Number(boardId))
+
+    if (index === -1) {
+      return HttpResponse.json(RES_DASHBOARD_FAIL_NOT_FOUND.res, { status: RES_DASHBOARD_FAIL_NOT_FOUND.code })
     }
 
-    if (token === '12341234' && boardId && result) {
-      return new HttpResponse(JSON.stringify(data), {
-        status: 200,
-      })
-    } else {
-      return new HttpResponse(null, {
-        status: 400,
-        statusText: 'failed',
-      })
-    }
-  }), */
+    boardListData[index] = { ...boardListData[index], ...updateData }
+
+    return HttpResponse.json(RES_DASHBOARD_UPDATE_SUCCESS.res, { status: RES_DASHBOARD_UPDATE_SUCCESS.code })
+  }),
 ]

--- a/src/mocks/dashboard.handler.ts
+++ b/src/mocks/dashboard.handler.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw'
 import { MSW_DASHBOARD_LAYOUTS } from './constants'
 import { boardListData } from './dashboardListData'
-import { defaultBoardData } from './data'
+import { defaultBoardData, LayoutDataType } from './data'
 import {
   RES_DASHBOARD_CREATE_FAIL,
   RES_DASHBOARD_CREATE_SUCCESS,
@@ -142,15 +142,12 @@ export const dashboardHandlers = [
   http.put('/dashboard/:boardId', async ({ request, params }) => {
     const { boardId } = params
 
-    const updateData = (await request.json()) as Partial<DashboardBody>
+    const updateData = (await request.json()) as Partial<LayoutDataType[]>
 
-    const index = boardListData.findIndex((board) => board.id === Number(boardId))
-
-    if (index === -1) {
-      return HttpResponse.json(RES_DASHBOARD_FAIL_NOT_FOUND.res, { status: RES_DASHBOARD_FAIL_NOT_FOUND.code })
-    }
-
-    boardListData[index] = { ...boardListData[index], ...updateData }
+    MSW_DASHBOARD_LAYOUTS[Number(boardId)] = MSW_DASHBOARD_LAYOUTS[Number(boardId)].map((item, index) => ({
+      ...item,
+      ...updateData[index],
+    }))
 
     return HttpResponse.json(RES_DASHBOARD_UPDATE_SUCCESS.res, { status: RES_DASHBOARD_UPDATE_SUCCESS.code })
   }),

--- a/src/mocks/resMessage.ts
+++ b/src/mocks/resMessage.ts
@@ -106,6 +106,15 @@ export const RES_DASHBOARD_DELETE_SUCCESS = {
   code: 201,
 }
 
+//대시보드 수정 성공
+export const RES_DASHBOARD_UPDATE_SUCCESS = {
+  res: {
+    success: true,
+    message: 'Dashboard updated successfully',
+  },
+  code: 200,
+}
+
 //대시보드 수정,삭제 실패: 해당 아이디 없음
 export const RES_DASHBOARD_FAIL_NOT_FOUND = {
   res: {


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

대시보드 편집 시 리사이징 불가 사이즈로 위젯 크기 변경시 변경 이전 크기로 강제 변환 동작 오류 수정  

<br />

## 변경사항

기존 atom 사용 + 리사이징 state추가 해서 플래그로 사용 

<br />

## 코드 참고사항

리사이징 동작 함수에서 
prev 로 설정시 atom 과 동기화 문제로 
강제 변환 될 때 변경된 배치를 반영하지 않고 리사이징 이전 배치로 돌아가는 문제가 발생, 
리사이징 set 할때 prev 가아닌 atom 을 직접 참조해서 set 하는 걸로 임시 해결 

추후 문제발생 가능성이 있어 수정이 필요함 
해당 부분 HACK 주석 추가 

close  #55  
