### PR TITLE
🐛 Fix: 대시보드 타이틀 편집 오류 수정 

### DIFF
--- a/src/components/editboard/BoardTitle.tsx
+++ b/src/components/editboard/BoardTitle.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@emotion/react'
 import { css } from '@emotion/react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useRecoilState, useRecoilValue } from 'recoil'
 
 import { editBoardDetails } from '@/api'
@@ -17,14 +17,17 @@ const BoardTitle = () => {
   const currentBoardId = useRecoilValue(currentBoardIdAtom)
   const { openAlert } = useAlert()
 
+  const currentBoard = useMemo(
+    () => boardListData.find((board) => board.id === currentBoardId),
+    [currentBoardId, boardListData],
+  )
+
   useEffect(() => {
-    if (currentBoardId === null) return
-    const currentBoard = boardListData.find((board) => board.id === currentBoardId)
     if (currentBoard) {
       setTitle(currentBoard.title)
       setOriginalTitle(currentBoard.title)
     }
-  }, [currentBoardId, boardListData])
+  }, [currentBoard])
 
   const handleClickEdit = async () => {
     setIsEdit(true)

--- a/src/components/editboard/BoardTitle.tsx
+++ b/src/components/editboard/BoardTitle.tsx
@@ -18,12 +18,11 @@ const BoardTitle = () => {
   const { openAlert } = useAlert()
 
   useEffect(() => {
-    if (currentBoardId) {
-      const currentBoard = boardListData.find((board) => board.id === currentBoardId)
-      if (currentBoard) {
-        setTitle(currentBoard.title)
-        setOriginalTitle(currentBoard.title)
-      }
+    if (currentBoardId === null) return
+    const currentBoard = boardListData.find((board) => board.id === currentBoardId)
+    if (currentBoard) {
+      setTitle(currentBoard.title)
+      setOriginalTitle(currentBoard.title)
     }
   }, [currentBoardId, boardListData])
 


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

대시보드 편집화면 진입 시 처음 보여지는 대시보드의 타이틀이 출력되지 않는 문제 해결 

<br />

## 변경사항

useEffect 만 사용해서 현재 보드 아이디를 리스트 목록에서 불러와 타이틀을 저장 했는데 
이 과정을 useMemo로 나눔 

<br />

## 코드 참고사항

close #61 
